### PR TITLE
Update Android mediation SDK to 7.4.0 to support mediation adapters

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -65,5 +65,5 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     // ironSource
-    implementation 'com.ironsource.sdk:mediationsdk:7.2.4.1'
+    implementation 'com.ironsource.sdk:mediationsdk:7.4.0'
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-IronSourceMediation_kotlinVersion=1.5.21
+IronSourceMediation_kotlinVersion=1.7.10
 IronSourceMediation_compileSdkVersion=29
 IronSourceMediation_buildToolsVersion=29.0.2
 IronSourceMediation_targetSdkVersion=29


### PR DESCRIPTION
In order to get mediation adapters like UnityAds to connect following the Android mediation integration guide recommended by the [RN SDK docs](https://developers.is.com/ironsource-mobile/react-native/mediation-networks-react-native/) I had to update the mediation SDK version in the React Native library to be 7.4.0.


After updating the version it connects successfully 👇 
<img width="446" alt="Screenshot 2023-08-18 at 16 13 05" src="https://github.com/ironsource-mobile/react-native-SDK/assets/22411478/0a23ed5b-e1ea-4329-9884-568bce9b2a37">
